### PR TITLE
Fix hotkeys

### DIFF
--- a/client.coffee
+++ b/client.coffee
@@ -150,7 +150,7 @@ $(document).ready () ->
       $('#b').text('Reveal')
       currentlyIsBuzzing = true
     return
-  $(document).keyup () ->
+  $(document).keyup (event) ->
     if document.activeElement.tagName != 'BODY'
       return
     if event.which == 32


### PR DESCRIPTION
Keyboard shortcuts were not functional and would return error message, event was not defined.

This fixes that by giving event as a parameter of the keyup function.